### PR TITLE
Workflow zu CD ändern

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,17 +9,23 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.101
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      shell: pwsh
+      run: ./publish.ps1
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: StudIPDownloader
+        path: D:/a/StudIP-Downloader/StudIP-Downloader/StudIPDownloader/bin/Debug/**/publish/*
     - name: Test
       run: dotnet test --no-restore --verbosity normal


### PR DESCRIPTION
Diese PR ändert den aktuellen Workflow zu Continuous Deployment.
So können auch intermediate builds heruntergeladen werden (siehe Beispiel [hier](https://github.com/ThexXTURBOXx/StudIP-Downloader/actions/runs/4708911351) oder [hier](https://github.com/yannik995/StudIP-Downloader/actions/runs/4708944455)).
Außerdem werden die GitHub actions aktualisiert, da einige noch NodeJS 12 verwenden und seit ein paar Monaten nur noch NodeJS 16 actions auf GitHub funktionieren.

Übrigens: Ja, der neue workflow ist langsamer als der alte, aber CD ist das normalerweise wert :)